### PR TITLE
Potential fix for code scanning alert no. 12: Log Injection

### DIFF
--- a/apps/assistant/src/apis/routers/query.py
+++ b/apps/assistant/src/apis/routers/query.py
@@ -8,6 +8,15 @@ from ...dependencies.rate_limiter import limiter
 
 logger = logging.getLogger(__name__)
 
+def _sanitize_for_logging(value):
+    """
+    Remove characters that could break log formatting, such as newlines.
+    """
+    if value is None:
+        return ""
+    text = str(value)
+    return text.replace("\r", "").replace("\n", "")
+
 router = APIRouter(prefix="/chat-query")
 
 @router.post("/")
@@ -49,5 +58,6 @@ async def chat_query(
             return {"response": "I apologize, but I encountered an issue processing your request. Please try again.", "session_id": session_id, "citations": []}
         
     except Exception as e:
-        logger.error(f"Error in {payload.structure} query: {str(e)}")
+        safe_structure = _sanitize_for_logging(payload.structure)
+        logger.error(f"Error in {safe_structure} query: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
Potential fix for [https://github.com/digdir/norge.no/security/code-scanning/12](https://github.com/digdir/norge.no/security/code-scanning/12)

To fix the problem, any user-controlled data used in log messages should be sanitized before logging, at least by removing newline (`\n`) and carriage return (`\r`) characters to prevent log entry splitting. More generally, we can centralize that behavior in a helper and apply it wherever we log tainted data.

The best minimal fix here is to introduce a small local sanitizer function that strips `\r` and `\n` from strings (and safely handles non-string/`None` inputs), and then use it on `payload.structure` before interpolating it into the error log message. We will only touch `apps/assistant/src/apis/routers/query.py`. Concretely:
- Add a helper function, e.g. `_sanitize_for_logging`, near the top of the file (after the logger definition) that:
  - Returns an empty string for `None`.
  - Converts non-string values to string, then removes `\r` and `\n`.
- In the `except` block of `chat_query`, change the `logger.error` call from directly using `payload.structure` to use `_sanitize_for_logging(payload.structure)`.

No new imports are required; we can do this with standard Python string operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
